### PR TITLE
Drop node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
https://travis-ci.org/walling/unorm/jobs/35466708 - looks like our test deps require 0.10 nowadays.
