### PR TITLE
prevent syntax error on old browsers

### DIFF
--- a/lib/unorm.js
+++ b/lib/unorm.js
@@ -380,7 +380,7 @@ UChar.udata={
       nfc: nfc,
       nfd: nfd,
       nfkc: nfkc,
-      nfkd: nfkd,
+      nfkd: nfkd
    };
 
    /*globals module:true,define:true*/


### PR DESCRIPTION
removed a comma so IE7 and below won't throw a syntax error.
