### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/src/unorm.js
+++ b/src/unorm.js
@@ -178,11 +178,7 @@
             var ret = [];
             for(var i = 0; i < decomp.length; ++i){
                var a = recursiveDecomp(cano, UChar.fromCharCode(decomp[i]));
-               //ret.concat(a); //<-why does not this work?
-               //following block is a workaround.
-               for(var j = 0; j < a.length; ++j){
-                  ret.push(a[j]);
-               }
+               ret = ret.concat(a);
             }
             return ret;
          } else {


### PR DESCRIPTION
Array.prototype.concat returns a shallow copy of the newly created array. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat