### PR TITLE
fix spdx license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version" : "1.6.0",
 	"description" : "JavaScript Unicode 8.0 Normalization - NFC, NFD, NFKC, NFKD. Read <http://unicode.org/reports/tr15/> UAX #15 Unicode Normalization Forms.",
 	"author": "Bjarke Walling <bwp@bwp.dk>",
-	"license": "MIT or GPL-2.0",
+	"license": "(MIT or GPL-2.0)",
 	"contributors": [
 		{ "name": "Bjarke Walling", "email": "bwp@bwp.dk" },
 		{ "name": "Oleg Grenrus", "email": "oleg.grenrus@iki.fi" },


### PR DESCRIPTION
Multible license-scanner tools have problems with this package because the license definition in the package.json is not valid due to [specification](https://docs.npmjs.com/files/package.json#license). This PR fixes it.

