### PR TITLE
update license to be valid spdx identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version" : "1.6.0",
 	"description" : "JavaScript Unicode 8.0 Normalization - NFC, NFD, NFKC, NFKD. Read <http://unicode.org/reports/tr15/> UAX #15 Unicode Normalization Forms.",
 	"author": "Bjarke Walling <bwp@bwp.dk>",
-	"license": "MIT or GPL-2.0",
+	"license": "(MIT OR GPL-2.0-or-later)",
 	"contributors": [
 		{ "name": "Bjarke Walling", "email": "bwp@bwp.dk" },
 		{ "name": "Oleg Grenrus", "email": "oleg.grenrus@iki.fi" },


### PR DESCRIPTION
`GPL-2.0` is deprecated and should be replaced with `GPL-2.0-or-later` or `GPL-2.0-only`.