### PR TITLE
"Fix" wrong dual licensing description

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The software dual licensed under the MIT and GPL licenses. MIT license:
+The software dual licensed under the MIT or GPL licenses. MIT license:
 
     Copyright (c) 2008-2013 Matsuza <matsuza@gmail.com>, Bjarke Walling <bwp@bwp.dk>
     

--- a/src/unorm.js
+++ b/src/unorm.js
@@ -1,7 +1,7 @@
 /*
  * UnicodeNormalizer 1.0.0
  * Copyright (c) 2008 Matsuza
- * Dual licensed under the MIT (MIT-LICENSE.txt) and GPL (GPL-LICENSE.txt) licenses.
+ * Dual licensed under the MIT (MIT-LICENSE.txt) or GPL (GPL-LICENSE.txt) licenses.
  * $Date: 2008-06-05 16:44:17 +0200 (Thu, 05 Jun 2008) $
  * $Rev: 13309 $
  */


### PR DESCRIPTION
As the original author of unorm.js, I should have written "Dual licensed under the MIT (MIT-LICENSE.txt) **or** GPL (GPL-LICENSE.txt) licenses."

As unorm.js has never been changed since I wrote it, I think we can change the licensing description.

Fixes #51